### PR TITLE
fix: enable reflect on 'type' attribute #26, check for http 403 status code #28

### DIFF
--- a/src/auro-avatar.js
+++ b/src/auro-avatar.js
@@ -134,7 +134,12 @@ class AuroAvatar extends LitElement {
       // when airport `code` attribute is declared
       url = `https://resource.alaskaair.net/-/media/Images/common-assets/destinations/${this.imageSize(this.type)}/${this.code}`;
 
-      const errorCodes = [404]; // eslint-disable-line no-magic-numbers
+      /* eslint-disable no-magic-numbers */
+      const errorCodes = [
+        403,
+        404
+      ];
+      /* eslint-enable no-magic-numbers */
 
       if (errorCodes.includes(this.urlStatus(url))) {
         url = `https://resource.alaskaair.net/-/media/Images/common-assets/destinations/${this.imageSize(this.type)}/partner`;

--- a/src/auro-avatar.js
+++ b/src/auro-avatar.js
@@ -61,7 +61,8 @@ class AuroAvatar extends LitElement {
         reflect: true
       },
       type: {
-        type: String
+        type: String,
+        reflect: true
       }
     };
   }


### PR DESCRIPTION
# Alaska Airlines Pull Request

- Enables `reflect` on `type` attribute in component properties. This improves compatibility with frameworks such as Svelte.
- Checks for http status code `403` in addition to `404` before rendering fallback image for invalid `code` attributes.

**Fixes:** #26, #28

## Type of change:

- [X] Revision of an existing capability

## Checklist:

- [X] My update follows the CONTRIBUTING guidelines of this project
- [X] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**