### PR TITLE
AURO MIGRATION: Update @alaskaairux/icons to 5.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@aurodesignsystem/auro-avatar",
-  "version": "5.3.1",
+  "version": "5.3.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@aurodesignsystem/auro-avatar",
-      "version": "5.3.1",
+      "version": "5.3.2",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -16,7 +16,7 @@
         "lit": "^3.2.1"
       },
       "devDependencies": {
-        "@alaskaairux/icons": "^4.44.1",
+        "@alaskaairux/icons": "^5.0.0",
         "@aurodesignsystem/design-tokens": "^4.13.0",
         "@aurodesignsystem/eslint-config": "^1.3.2",
         "@aurodesignsystem/webcorestylesheets": "^6.0.2",
@@ -65,15 +65,15 @@
         "node": "^20.x || ^22.x "
       },
       "peerDependencies": {
-        "@alaskaairux/icons": "^4.43.0",
+        "@alaskaairux/icons": "^5.0.0",
         "@aurodesignsystem/design-tokens": "^4.13.0",
         "@aurodesignsystem/webcorestylesheets": "^6.0.2"
       }
     },
     "node_modules/@alaskaairux/icons": {
-      "version": "4.44.1",
-      "resolved": "https://registry.npmjs.org/@alaskaairux/icons/-/icons-4.44.1.tgz",
-      "integrity": "sha512-6KI8kFphlnpYo2t1hUvj1N2kybkbThg5Ohv9WVR1mEZ4b1UM3+AIF0eoL2atkW+7EO7GjUlE6NhuwJvuy7y7Ig==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@alaskaairux/icons/-/icons-5.0.0.tgz",
+      "integrity": "sha512-EOSBT2gKcEQJZa18PvVSTdmhigDwNonsEgPtu6K0FgM07z+X5BpDElMy/dy/OkKpsuLzJNoDyXTxGpB7BapSEA==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -81,7 +81,7 @@
         "svgo": "^3.3.2"
       },
       "engines": {
-        "node": "^18 || ^20"
+        "node": "^20 || ^22"
       }
     },
     "node_modules/@alaskaairux/icons/node_modules/ansi-styles": {

--- a/package.json
+++ b/package.json
@@ -26,12 +26,12 @@
     "lit": "^3.2.1"
   },
   "peerDependencies": {
-    "@alaskaairux/icons": "^4.43.0",
+    "@alaskaairux/icons": "^5.0.0",
     "@aurodesignsystem/design-tokens": "^4.13.0",
     "@aurodesignsystem/webcorestylesheets": "^6.0.2"
   },
   "devDependencies": {
-    "@alaskaairux/icons": "^4.44.1",
+    "@alaskaairux/icons": "^5.0.0",
     "@aurodesignsystem/design-tokens": "^4.13.0",
     "@aurodesignsystem/eslint-config": "^1.3.2",
     "@aurodesignsystem/webcorestylesheets": "^6.0.2",


### PR DESCRIPTION
Update the @alaskaairux/icons package to version 5.0.0
BREAKING CHANGE: @alaskaairux/icons@5.0.0 is not compatible with node 18. Moves to node 20-22.
