### PR TITLE
AURO MIGRATION: Sync templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -43,7 +43,7 @@ body:
   - type: input
     id: version
     attributes:
-      label: Which version of auro-templates do you have installed?
+      label: Which version of auro-avatar do you have installed?
   - type: markdown
     attributes:
       value: >

--- a/.github/ISSUE_TEMPLATE/design_handoff.yaml
+++ b/.github/ISSUE_TEMPLATE/design_handoff.yaml
@@ -1,0 +1,46 @@
+name: Design Handoff
+description: Handoff design work to the development team.
+type: "Task"
+title: 'Design Handoff: [Feature Name]'
+projects: ["AlaskaAirlines/19"]
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Design Description
+      description: A clear and concise description of what is new or changed in the design.
+  - type: input
+    id: figma
+    attributes:
+      label: Link to Figma file version.
+      description: This link should be to a specific version of the Figma file that is ready for development.
+  - type: textarea
+    id: issues
+    attributes:
+      label: Blocking Issues and Questions
+      description: List any issues and questions that are blocking the handoff acceptance.
+  - type: textarea
+    id: nonblockers
+    attributes:
+      label: Non-Blocking Issues and Questions
+      description: List any unresolved issues and questions that are not blocking the handoff acceptance.
+  - type: textarea
+    id: tech
+    attributes:
+      label: Engineering Implementation Notes
+      description: List any initial ideas for how engineering will implement the design.
+  - type: checkboxes
+    id: review
+    attributes:
+      label: Points of Review
+      description: This is a list of items that the development team should review before accepting handoff.
+      options:
+        - label: The design work is part of a Story or Support ticket and linked as a parent issue.
+        - label: The linked Figma file is the correct version.
+        - label: Design is consistent with the design system.
+        - label: UX is fully explained and documented.
+        - label: Responsive design has been considered.
+        - label: VoiceOver Experience has been considered.
+        - label: Other accessibility considerations have been discussed.
+        - label: All CSS rule values are based on current design tokens.
+        - label: There are no design features which require feature additions or changes have not been approved by Product.

--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -18,7 +18,7 @@ repository:
   has_downloads: true
 
   # Updates the default branch for this repository.
-  default_branch: main
+  default_branch: dev
 
   # Either `true` to enable automatic deletion of branches on merge, or `false` to disable
   delete_branch_on_merge: true
@@ -29,7 +29,7 @@ repository:
 
   # Either `true` to allow merging pull requests with a merge commit, or `false`
   # to prevent merging pull requests with merge commits.
-  allow_merge_commit: false
+  allow_merge_commit: true
 
   # Either `true` to allow rebase-merging pull requests, or `false` to prevent
   # rebase-merging.
@@ -47,39 +47,3 @@ teams:
     permission: admin
   - name: nonauroteamwriteaccess
     permission: push
-
-branches:
-  - &default_protection
-    # https://developer.github.com/v3/repos/branches/#update-branch-protection
-    # Branch Protection settings. Set to null to disable
-    protection:
-      # Required. Require at least one approving review on a pull request, before merging. Set to null to disable.
-      required_pull_request_reviews:
-        # The number of approvals required. (1-6)
-        required_approving_review_count: 1
-        # Dismiss approved reviews automatically when a new commit is pushed.
-        dismiss_stale_reviews: true
-        # Blocks merge until code owners have reviewed.
-        require_code_owner_reviews: true
-        # Required. Require status checks to pass before merging. Set to null to disable
-        # Specify which users and teams can dismiss pull request reviews. Pass an empty dismissal_restrictions object to disable. User and team dismissal_restrictions are only available for organization-owned repositories. Omit this parameter for personal repositories.
-        dismissal_restrictions:
-          users: ["blackfalcon"]
-      # Required. Require status checks to pass before merging. Set to null to disable
-      required_status_checks:
-        # Required. Require branches to be up to date before merging.
-        strict: true
-        # Required. The list of status checks to require in order to merge into this branch
-        contexts: ["test (20.x)", "test (22.x)", "license/cla"]
-      # Required. Enforce all configured restrictions for administrators. Set to true to enforce required status checks for repository administrators. Set to null to disable.
-      enforce_admins: false
-      # Required. Restrict who can push to this branch. Team and user restrictions are only available for organization-owned repositories. Set to null to disable.
-      restrictions: null
-      # Prevent merge commits from being pushed to matching branches
-      required_linear_history: true
-
-  - name: main
-    <<: *default_protection
-
-  - name: beta
-    <<: *default_protection

--- a/.github/workflows/add-project.yml
+++ b/.github/workflows/add-project.yml
@@ -4,7 +4,6 @@ on:
   issues:
     types: [opened]
 
-
 jobs:
   action:
     uses: AlaskaAirlines/auro-actions/.github/workflows/add-project.yml@main


### PR DESCRIPTION
Resolves AlaskaAirlines/auro-cli#208

## Summary by Sourcery

Synchronize GitHub settings and issue templates for AURO migration by switching the default branch to dev, adjusting merge policies, removing outdated branch protection, updating the bug report prompt, and adding a new design handoff template.

Enhancements:
- Change default branch to dev and enable merge commits
- Remove existing branch protection configurations
- Update bug report template to reference auro-avatar instead of auro-templates
- Add a new Design Handoff issue template
- Clean up the Add Project workflow formatting